### PR TITLE
Bring back python 3.8

### DIFF
--- a/.github/workflows/pythonapp.yml
+++ b/.github/workflows/pythonapp.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python_version: ['3.7']
+        python_version: ['3.7', '3.8']
 
     steps:
     - uses: actions/checkout@v2


### PR DESCRIPTION
tensorflow is now an extra in the ctt project allowing to test with python 3.8 in here